### PR TITLE
Rebased android jolt support

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -6,7 +6,7 @@ on:
 env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes module_jolt_enabled=no
+  SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes module_jolt_enabled=yes
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-android

--- a/modules/jolt/SCsub
+++ b/modules/jolt/SCsub
@@ -87,11 +87,18 @@ elif env["platform"] == "macos":
 elif env["platform"] == "android":
     #cmake_platform_opts += ' -DANDROID_NDK_VERSION=23.2.8568313'
     cmake_platform_opts += ' -DCMAKE_SYSTEM_NAME=Android'
-    cmake_platform_opts += ' -DCMAKE_SYSTEM_VERSION=23'
+    cmake_platform_opts += ' -DCMAKE_SYSTEM_VERSION=24'
+    cmake_platform_opts += ' -DANDROID_ABI=arm64-v8a'
+    cmake_platform_opts += ' -DANDROID_NDK=/Users/gordon/Library/Android/sdk/ndk/23.2.8568313'
+    cmake_platform_opts += ' -DCMAKE_ANDROID_STL_TYPE=c++_shared'
+    cmake_platform_opts += ' -DANDROID_STL=c++_shared'
     cmake_platform_opts += ' -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a'
+    cmake_platform_opts += ' -DCMAKE_TOOLCHAIN_FILE=/Users/gordon/Library/Android/Sdk/ndk/23.2.8568313/build/cmake/android.toolchain.cmake'
     cmake_platform_opts += ' -DCMAKE_ANDROID_NDK=/Users/gordon/Library/Android/sdk/ndk/23.2.8568313'
     cmake_platform_opts += ' -DANDROID_ARM_NEON=ON'
+    cmake_platform_opts += ' -DANDROID_PLATFORM=android-24'
     cmake_platform_opts += ' -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang'
+    cmake_platform_opts += ' -DCMAKE_CXX_FLAGS="-fPIC"'
     cmake_generator_type = '"Unix Makefiles"'
 
 elif env["platform"] == "windows":
@@ -171,6 +178,7 @@ cmake_opts += " -DMI_BUILD_SHARED=OFF "
 cmake_opts += " -DMI_BUILD_OBJECT=OFF "
 cmake_opts += " -DMI_BUILD_TESTS=OFF "
 cmake_opts += " -DMI_OVERRIDE=OFF "
+cmake_opts += " -DMI_USE_CXX=OFF "
 if env["platform"] == "windows":
     cmake_opts += " -DCMAKE_CXX_FLAGS_RELEASE=/MT"
     cmake_opts += " -DCMAKE_C_FLAGS_RELEASE=/MT"

--- a/modules/jolt/SCsub
+++ b/modules/jolt/SCsub
@@ -84,6 +84,10 @@ elif env["platform"] == "macos":
     elif env["arch"] == "x86_64":
         cmake_platform_opts += ' -DCMAKE_OSX_ARCHITECTURES="x86_64" -DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" '
 
+elif env["platform"] == "android":
+    cmake_platform_opts += ' -DCMAKE_OSX_ARCHITECTURES="aarch64" -DCROSS_COMPILE_ARM=1'
+    cmake_generator_type = '"Unix Makefiles"'
+
 elif env["platform"] == "windows":
     cmake_generator_type = "Ninja"
 

--- a/modules/jolt/SCsub
+++ b/modules/jolt/SCsub
@@ -85,7 +85,13 @@ elif env["platform"] == "macos":
         cmake_platform_opts += ' -DCMAKE_OSX_ARCHITECTURES="x86_64" -DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" '
 
 elif env["platform"] == "android":
-    cmake_platform_opts += ' -DCMAKE_OSX_ARCHITECTURES="aarch64" -DCROSS_COMPILE_ARM=1'
+    #cmake_platform_opts += ' -DANDROID_NDK_VERSION=23.2.8568313'
+    cmake_platform_opts += ' -DCMAKE_SYSTEM_NAME=Android'
+    cmake_platform_opts += ' -DCMAKE_SYSTEM_VERSION=23'
+    cmake_platform_opts += ' -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a'
+    cmake_platform_opts += ' -DCMAKE_ANDROID_NDK=/Users/gordon/Library/Android/sdk/ndk/23.2.8568313'
+    cmake_platform_opts += ' -DANDROID_ARM_NEON=ON'
+    cmake_platform_opts += ' -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang'
     cmake_generator_type = '"Unix Makefiles"'
 
 elif env["platform"] == "windows":

--- a/modules/jolt/SCsub
+++ b/modules/jolt/SCsub
@@ -85,18 +85,27 @@ elif env["platform"] == "macos":
         cmake_platform_opts += ' -DCMAKE_OSX_ARCHITECTURES="x86_64" -DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" '
 
 elif env["platform"] == "android":
-    #cmake_platform_opts += ' -DANDROID_NDK_VERSION=23.2.8568313'
+    android_abi = ""
+    if env["arch"] == "arm32":
+        android_abi = "armeabi-v7a"
+    elif env["arch"] == "arm64":
+        android_abi = "arm64-v8a"
+    elif env["arch"] == "x86_32":
+        android_abi = "x86"
+    elif env["arch"] == "x86_64":
+        android_abi = "x86_64"
+    android_ndk = env["ANDROID_NDK_ROOT"]
     cmake_platform_opts += ' -DCMAKE_SYSTEM_NAME=Android'
     cmake_platform_opts += ' -DCMAKE_SYSTEM_VERSION=24'
-    cmake_platform_opts += ' -DANDROID_ABI=arm64-v8a'
-    cmake_platform_opts += ' -DANDROID_NDK=/Users/gordon/Library/Android/sdk/ndk/23.2.8568313'
+    cmake_platform_opts += ' -DANDROID_ABI=' + android_abi
+    cmake_platform_opts += ' -DANDROID_NDK=' + android_ndk
     cmake_platform_opts += ' -DCMAKE_ANDROID_STL_TYPE=c++_shared'
     cmake_platform_opts += ' -DANDROID_STL=c++_shared'
-    cmake_platform_opts += ' -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a'
-    cmake_platform_opts += ' -DCMAKE_TOOLCHAIN_FILE=/Users/gordon/Library/Android/Sdk/ndk/23.2.8568313/build/cmake/android.toolchain.cmake'
-    cmake_platform_opts += ' -DCMAKE_ANDROID_NDK=/Users/gordon/Library/Android/sdk/ndk/23.2.8568313'
+    cmake_platform_opts += ' -DCMAKE_ANDROID_ARCH_ABI=' + android_abi
+    cmake_platform_opts += ' -DCMAKE_TOOLCHAIN_FILE=' + android_ndk + '/build/cmake/android.toolchain.cmake'
+    cmake_platform_opts += ' -DCMAKE_ANDROID_NDK=' + android_ndk
     cmake_platform_opts += ' -DANDROID_ARM_NEON=ON'
-    cmake_platform_opts += ' -DANDROID_PLATFORM=android-24'
+    cmake_platform_opts += ' -DANDROID_PLATFORM=' + env["ndk_platform"]
     cmake_platform_opts += ' -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang'
     cmake_platform_opts += ' -DCMAKE_CXX_FLAGS="-fPIC"'
     cmake_generator_type = '"Unix Makefiles"'


### PR DESCRIPTION
Android porting for jolt is a bit complex due to the bridge from android cmake to scons.