### PR TITLE
Fix msvc jolt issue - a MSVC upgrade breaks support for jolt compilation

### DIFF
--- a/modules/jolt/SCsub
+++ b/modules/jolt/SCsub
@@ -44,6 +44,8 @@ cmake_opts += " -DTARGET_VIEWER=OFF "
 cmake_opts += " -DTARGET_UNIT_TESTS=OFF "
 cmake_opts += " -DTARGET_PERFORMANCE_TEST=OFF "
 cmake_opts += " -DDEBUG_RENDERER_IN_DISTRIBUTION=ON "
+# disabled due to MSVC incompatibility with latest MSVC on windows
+cmake_opts += " -DENABLE_ALL_WARNINGS=OFF "
 
 # TODO enable SIMD again - ASAP
 # Disables all the SIMD optimizations because at the moment we are unable to properly


### PR DESCRIPTION
Resolves:
```
Error: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\immintrin.h(105): error C2220: the following warning is treated as an error
Warning: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\immintrin.h(105): warning C4514: '__check_isa_support': unreferenced inline function has been removed
Warning: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\immintrin.h(118): warning C4514: '__check_isa_avx10_512': unreferenced inline function has been removed
Warning: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\immintrin.h(125): warning C4514: '__check_arch_support': unreferenced inline function has been removed
```